### PR TITLE
fix: Typo in VScout name

### DIFF
--- a/chapter11.md
+++ b/chapter11.md
@@ -36,4 +36,4 @@ Receive notifications directly into your email address when transactions occur o
 
 * [Avalanche Explorer](https://explorer.avax.network)
 * [Avascan](https://avascan.info/)
-* [Vscout](https://vscout.io/)
+* [VScout](https://vscout.io/)

--- a/chapter11.md
+++ b/chapter11.md
@@ -36,4 +36,4 @@ Receive notifications directly into your email address when transactions occur o
 
 * [Avalanche Explorer](https://explorer.avax.network)
 * [Avascan](https://avascan.info/)
-* [Vsout](https://vscout.io/)
+* [Vscout](https://vscout.io/)


### PR DESCRIPTION
Just noticed a small typo in VScout name . 